### PR TITLE
Slight improvment to `cepl.camera.base:with-base-camera`

### DIFF
--- a/base-camera.lisp
+++ b/base-camera.lisp
@@ -39,15 +39,15 @@
                      :fov fov))
 
 (defmacro with-base-camera (slots cam &body body)
-
-  (assert (every (lambda (x) (member x '(viewport space near far fov in-space
-                                         perspective)))
+  (assert (every (lambda (x)
+                   (member (intern (symbol-name x) :keyword)
+                           '(:viewport :space :near :far :fov :in-space :perspective)))
                  slots))
   `(symbol-macrolet
        ,(mapcar (lambda (x)
                   `(,x (,(cepl-utils:symb-package :cepl.camera.base :base-camera- x)
-                         ,cam)))
-                slots)
+                        ,cam)))
+         slots)
      ,@body))
 
 (defun update-cam->clip (base-camera)


### PR DESCRIPTION

## Before

This:
```lisp
(cepl.camera.base:with-base-camera (cepl.camera.base:fov cepl.camera.base:near cepl.camera.base:far) *camera*
  (setf cepl.camera.base:fov 90.0
        cepl.camera.base:near -100.0
        cepl.camera.base:far 100.0))
```
(notice the abundance of  `cepl.camera.base:`)
Would expand to:
```lisp
(SYMBOL-MACROLET ((CEPL.CAMERA.BASE:FOV
                   (CEPL.CAMERA.BASE::BASE-CAMERA-FOV *CAMERA*))
                  (CEPL.CAMERA.BASE:NEAR
                   (CEPL.CAMERA.BASE::BASE-CAMERA-NEAR *CAMERA*))
                  (CEPL.CAMERA.BASE:FAR
                   (CEPL.CAMERA.BASE::BASE-CAMERA-FAR *CAMERA*)))
  (SETF CEPL.CAMERA.BASE:FOV 90.0
        CEPL.CAMERA.BASE:NEAR -100.0
        CEPL.CAMERA.BASE:FAR 100.0))
```

## After

This:
```lisp
(cepl.camera.base:with-base-camera (fov near far) *camera*
    (setf fov 90.0
          near -100.0
          far 100.0))
```
(notice the lack of  `cepl.camera.base:`)
Was rejected because of the assert, but now will expand to that:
```lisp
(SYMBOL-MACROLET ((FOV (CEPL.CAMERA.BASE::BASE-CAMERA-FOV *CAMERA*))
                  (NEAR (CEPL.CAMERA.BASE::BASE-CAMERA-NEAR *CAMERA*))
                  (FAR (CEPL.CAMERA.BASE::BASE-CAMERA-FAR *CAMERA*)))
  (SETF FOV 90.0
        NEAR -100.0
        FAR 100.0))
```